### PR TITLE
Avoid boxing.

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -89,17 +89,17 @@ impl Phenotype for StringGuess {
 
 fn main() {
     let input = "HelloWorld";
-    let mut population: Vec<Box<StringGuess>> = Vec::with_capacity(500);
+    let mut population: Vec<StringGuess> = Vec::with_capacity(500);
     let mut rng = ::rand::thread_rng();
     for _ in 0..500 {
         // Generate a random string
         let guess = rng.gen_ascii_chars().take(input.len()).collect::<String>();
-        population.push(Box::new(StringGuess {
+        population.push(StringGuess {
             target: String::from(input),
             guess: guess,
-        }));
+        });
     }
-    let mut s = *Simulator::builder()
+    let mut s = Simulator::builder()
                      .set_population(&population)
                      .set_selector(Box::new(RouletteSelector::new(40)))
                      .set_max_iters(1000)
@@ -112,7 +112,7 @@ fn main() {
                  index,
                  result.fitness(),
                  result.guess);
-        if (*result).guess == input {
+        if result.guess == input {
             break;
         }
         index += 1;

--- a/examples/max_parabole.rs
+++ b/examples/max_parabole.rs
@@ -66,8 +66,8 @@ impl Clone for MyData {
 }
 
 fn main() {
-    let population = (-300..300).map(|i| Box::new(MyData{ x: i as f64 })).collect();
-    let mut s = *Simulator::builder()
+    let population = (-300..300).map(|i| MyData{ x: i as f64 }).collect();
+    let mut s = Simulator::builder()
                             .set_population(&population)
                             .set_selector(Box::new(StochasticSelector::new(10)))
                             .set_max_iters(50)

--- a/examples/max_parabole_steps.rs
+++ b/examples/max_parabole_steps.rs
@@ -68,8 +68,8 @@ impl Clone for MyData {
 }
 
 fn main() {
-    let population = (-300..300).map(|i| Box::new(MyData{ x: i as f64 })).collect();
-    let mut s = *Simulator::builder()
+    let population = (-300..300).map(|i| MyData{ x: i as f64 }).collect();
+    let mut s = Simulator::builder()
                             .set_population(&population)
                             .set_selector(Box::new(StochasticSelector::new(10)))
                             .set_max_iters(50)

--- a/examples/truck_loading.rs
+++ b/examples/truck_loading.rs
@@ -109,7 +109,7 @@ impl Clone for LoadingScheme {
 }
 
 fn main() {
-    let mut population: Vec<Box<LoadingScheme>> = Vec::with_capacity(300);
+    let mut population: Vec<LoadingScheme> = Vec::with_capacity(300);
     let mut rng = ::rand::thread_rng();
     for _ in 0..300 {
         let mut pheno: Scheme = Vec::with_capacity(PACKAGES.len());
@@ -117,9 +117,9 @@ fn main() {
             let index = rng.gen::<usize>() % NUM_TRUCKS;
             pheno.push((index, PACKAGES[j]));
         }
-        population.push(Box::new(LoadingScheme { scheme: pheno }));
+        population.push(LoadingScheme { scheme: pheno });
     }
-    let mut s = *Simulator::builder()
+    let mut s = Simulator::builder()
                      .set_population(&population)
                      .set_selector(Box::new(RouletteSelector::new(10)))
                      .set_max_iters(50)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,9 +110,9 @@
 //!
 //! ```ignore
 //! // Generate a random population.
-//! let mut tests: Vec<Box<Test>> = Vec::new();
+//! let mut tests: Vec<Test> = Vec::new();
 //! for i in 0..100 {
-//!     tests.push(Box::new(Test { i: i + 10 }));
+//!     tests.push(Test { i: i + 10 });
 //! }
 //! // Create a simulator using a builder.
 //! let mut s = *seq::Simulator::builder()

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -23,16 +23,16 @@ mod earlystopper;
 
 /// A `Builder` can create new instances of an object.
 /// For this library, only `Simulation` objects use this `Builder`.
-pub trait Builder<T> {
+pub trait Builder<T: ?Sized> {
     /// Return the result.
-    fn build(self) -> T;
+    fn build(self) -> T where T: Sized;
 }
 
 /// Simulation run time is defined in nanoseconds.
 pub type NanoSecond = i64;
 /// The result of a simulation, containing the best phenotype
 /// or an error message.
-pub type SimResult<T> = Result<Box<T>, String>;
+pub type SimResult<T> = Result<T, String>;
 
 /// The result of running a single step.
 #[derive(PartialEq,Eq,Debug)]
@@ -57,10 +57,10 @@ pub enum RunResult {
 /// A `Simulation` is an execution of a genetic algorithm.
 pub trait Simulation<T: Phenotype> {
     /// A `Builder` is used to create instances of a `Simulation`.
-    type B: Builder<Box<Self>>;
+    type B: Builder<Self>;
 
     /// Create a `Builder` to create an instance.
-    fn builder() -> Self::B;
+    fn builder() -> Self::B where Self: Sized;
     /// Run the simulation completely.
     fn run(&mut self) -> RunResult;
     /// Make one step in the simulation. This function returns a `StepResult`:

--- a/src/sim/select/max.rs
+++ b/src/sim/select/max.rs
@@ -38,7 +38,7 @@ impl MaximizeSelector {
 
 impl<T: Phenotype> Selector<T> for MaximizeSelector {
     fn select(&self,
-              population: &Vec<Box<T>>,
+              population: &Vec<T>,
               fitness_type: FitnessType)
               -> Result<Parents<T>, String> {
         if self.count <= 0 || self.count % 2 != 0 || self.count * 2 >= population.len() {
@@ -54,7 +54,7 @@ impl<T: Phenotype> Selector<T> for MaximizeSelector {
         if let FitnessType::Maximize = fitness_type {
             cloned.reverse();
         }
-        let sorted: Vec<&Box<T>> = cloned.iter().take(self.count).collect();
+        let sorted: Vec<&T> = cloned.iter().take(self.count).collect();
         let mut index = 0;
         let mut result: Parents<T> = Vec::new();
         while index < sorted.len() {
@@ -100,28 +100,28 @@ mod tests {
     #[test]
     fn test_count_zero() {
         let selector = MaximizeSelector::new(0);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert!(selector.select(&population, FitnessType::Minimize).is_err());
     }
 
     #[test]
     fn test_count_odd() {
         let selector = MaximizeSelector::new(5);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert!(selector.select(&population, FitnessType::Minimize).is_err());
     }
 
     #[test]
     fn test_count_too_large() {
         let selector = MaximizeSelector::new(100);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert!(selector.select(&population, FitnessType::Minimize).is_err());
     }
 
     #[test]
     fn test_result_size() {
         let selector = MaximizeSelector::new(20);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert_eq!(20,
                    selector.select(&population, FitnessType::Minimize).unwrap().len() * 2);
     }
@@ -129,10 +129,10 @@ mod tests {
     #[test]
     fn test_result_ok() {
         let selector = MaximizeSelector::new(20);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         // The lowest fitness should be zero.
         assert!((0.0 -
-                 (*selector.select(&population, FitnessType::Minimize)
+                 (selector.select(&population, FitnessType::Minimize)
                            .unwrap()[0]
                        .0)
                      .fitness())

--- a/src/sim/select/mod.rs
+++ b/src/sim/select/mod.rs
@@ -34,8 +34,8 @@ pub use self::tournament::TournamentSelector;
 pub use self::stochastic::StochasticSelector;
 pub use self::roulette::RouletteSelector;
 
-/// `Parents` come in a `Vec` of two `Box<T>`'s.
-pub type Parents<T> = Vec<(Box<T>, Box<T>)>;
+/// `Parents` come in a `Vec` of two `T`'s.
+pub type Parents<T> = Vec<(T, T)>;
 
 /// A `Selector` can select `Parents` for a new iteration of a `Simulation`.
 pub trait Selector<T: Phenotype> {
@@ -47,7 +47,7 @@ pub trait Selector<T: Phenotype> {
     ///
     /// Otherwise it contains a vector of parent pairs wrapped in `Ok`.
     fn select(&self,
-              population: &Vec<Box<T>>,
+              population: &Vec<T>,
               fitness_type: FitnessType)
               -> Result<Parents<T>, String>;
 }

--- a/src/sim/select/roulette.rs
+++ b/src/sim/select/roulette.rs
@@ -40,7 +40,7 @@ impl RouletteSelector {
 }
 
 impl<T: Phenotype> Selector<T> for RouletteSelector {
-    fn select(&self, population: &Vec<Box<T>>, _: FitnessType) -> Result<Parents<T>, String> {
+    fn select(&self, population: &Vec<T>, _: FitnessType) -> Result<Parents<T>, String> {
         if self.count <= 0 || self.count % 2 != 0 || self.count >= population.len() {
             return Err(format!("Invalid parameter `count`: {}. Should be larger than zero, a \
                                 multiple of two and less than the population size.",
@@ -66,7 +66,7 @@ impl<T: Phenotype> Selector<T> for RouletteSelector {
 
         let mut selected = 0;
         while selected < self.count {
-            let mut inner_selected: Vec<Box<T>> = Vec::with_capacity(2);
+            let mut inner_selected: Vec<T> = Vec::with_capacity(2);
             while inner_selected.len() < 2 {
                 let c = between.ind_sample(&mut rng);
 
@@ -122,28 +122,28 @@ mod tests {
     #[test]
     fn test_count_zero() {
         let selector = RouletteSelector::new(0);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert!(selector.select(&population, FitnessType::Minimize).is_err());
     }
 
     #[test]
     fn test_count_odd() {
         let selector = RouletteSelector::new(5);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert!(selector.select(&population, FitnessType::Minimize).is_err());
     }
 
     #[test]
     fn test_count_too_large() {
         let selector = RouletteSelector::new(100);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert!(selector.select(&population, FitnessType::Minimize).is_err());
     }
 
     #[test]
     fn test_result_size() {
         let selector = RouletteSelector::new(20);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert_eq!(20,
                    selector.select(&population, FitnessType::Minimize).unwrap().len() * 2);
     }

--- a/src/sim/select/stochastic.rs
+++ b/src/sim/select/stochastic.rs
@@ -40,7 +40,7 @@ impl StochasticSelector {
 }
 
 impl<T: Phenotype> Selector<T> for StochasticSelector {
-    fn select(&self, population: &Vec<Box<T>>, _: FitnessType) -> Result<Parents<T>, String> {
+    fn select(&self, population: &Vec<T>, _: FitnessType) -> Result<Parents<T>, String> {
         if self.count <= 0 || self.count % 2 != 0 || self.count >= population.len() {
             return Err(format!("Invalid parameter `count`: {}. Should be larger than zero, a \
                                 multiple of two and less than the population size.",
@@ -97,28 +97,28 @@ mod tests {
     #[test]
     fn test_count_zero() {
         let selector = StochasticSelector::new(0);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert!(selector.select(&population, FitnessType::Minimize).is_err());
     }
 
     #[test]
     fn test_count_odd() {
         let selector = StochasticSelector::new(5);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert!(selector.select(&population, FitnessType::Minimize).is_err());
     }
 
     #[test]
     fn test_count_too_large() {
         let selector = StochasticSelector::new(100);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert!(selector.select(&population, FitnessType::Minimize).is_err());
     }
 
     #[test]
     fn test_result_size() {
         let selector = StochasticSelector::new(20);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert_eq!(20,
                    selector.select(&population, FitnessType::Minimize).unwrap().len() * 2);
     }

--- a/src/sim/select/tournament.rs
+++ b/src/sim/select/tournament.rs
@@ -45,7 +45,7 @@ impl TournamentSelector {
 
 impl<T: Phenotype> Selector<T> for TournamentSelector {
     fn select(&self,
-              population: &Vec<Box<T>>,
+              population: &Vec<T>,
               fitness_type: FitnessType)
               -> Result<Parents<T>, String> {
         if self.count <= 0 || self.count % 2 != 0 || self.count * 2 >= population.len() {
@@ -62,7 +62,7 @@ impl<T: Phenotype> Selector<T> for TournamentSelector {
         let mut result: Parents<T> = Vec::new();
         let mut rng = ::rand::thread_rng();
         for _ in 0..(self.count / 2) {
-            let mut tournament: Vec<Box<T>> = Vec::with_capacity(self.participants);
+            let mut tournament: Vec<T> = Vec::with_capacity(self.participants);
             for _ in 0..self.participants {
                 let index = rng.gen_range::<usize>(0, population.len());
                 tournament.push(population[index].clone());
@@ -119,42 +119,42 @@ mod tests {
     #[test]
     fn test_count_zero() {
         let selector = TournamentSelector::new(0, 1);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert!(selector.select(&population, FitnessType::Minimize).is_err());
     }
 
     #[test]
     fn test_participants_zero() {
         let selector = TournamentSelector::new(2, 0);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert!(selector.select(&population, FitnessType::Minimize).is_err());
     }
 
     #[test]
     fn test_count_odd() {
         let selector = TournamentSelector::new(5, 1);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert!(selector.select(&population, FitnessType::Minimize).is_err());
     }
 
     #[test]
     fn test_count_too_large() {
         let selector = TournamentSelector::new(100, 1);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert!(selector.select(&population, FitnessType::Minimize).is_err());
     }
 
     #[test]
     fn test_participants_too_large() {
         let selector = TournamentSelector::new(2, 100);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert!(selector.select(&population, FitnessType::Minimize).is_err());
     }
 
     #[test]
     fn test_result_size() {
         let selector = TournamentSelector::new(20, 5);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
         assert_eq!(20,
                    selector.select(&population, FitnessType::Minimize).unwrap().len() * 2);
     }

--- a/src/sim/seq.rs
+++ b/src/sim/seq.rs
@@ -32,7 +32,7 @@ use time::SteadyTime;
 /// A sequential implementation of `::sim::Simulation`.
 /// The genetic algorithm is run in a single thread.
 pub struct Simulator<T: Phenotype> {
-    population: Vec<Box<T>>,
+    population: Vec<T>,
     iter_limit: IterLimit,
     selector: Box<Selector<T>>,
     fitness_type: FitnessType,
@@ -81,11 +81,11 @@ impl<T: Phenotype> Simulation<T> for Simulator<T> {
             }
             let parents = parents_tmp.ok().unwrap();
             // Create children from the selected parents and mutate them.
-            let mut children: Vec<Box<T>> = parents.iter()
-                                                   .map(|pair: &(Box<T>, Box<T>)| {
-                                                       pair.0.crossover(&*(pair.1))
+            let mut children: Vec<T> = parents.iter()
+                                                   .map(|pair: &(T, T)| {
+                                                       pair.0.crossover(&(pair.1))
                                                    })
-                                                   .map(|c| Box::new(c.mutate()))
+                                                   .map(|c| c.mutate())
                                                    .collect();
             // Kill off parts of the population at random to make room for the children
             self.kill_off(children.len());
@@ -181,7 +181,7 @@ impl<T: Phenotype> SimulatorBuilder<T> {
     /// Set the population of the resulting `Simulator`.
     ///
     /// Returns itself for chaining purposes.
-    pub fn set_population(mut self, pop: &Vec<Box<T>>) -> Self {
+    pub fn set_population(mut self, pop: &Vec<T>) -> Self {
         self.sim.population = pop.clone();
         self
     }
@@ -224,9 +224,9 @@ impl<T: Phenotype> SimulatorBuilder<T> {
     }
 }
 
-impl<T: Phenotype> Builder<Box<Simulator<T>>> for SimulatorBuilder<T> {
-    fn build(self) -> Box<Simulator<T>> {
-        Box::new(self.sim)
+impl<T: Phenotype> Builder<Simulator<T>> for SimulatorBuilder<T> {
+    fn build(self) -> Simulator<T> {
+        self.sim
     }
 }
 
@@ -265,8 +265,8 @@ mod tests {
     #[test]
     fn test_kill_off_count() {
         let selector = MaximizeSelector::new(2);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
-        let mut s = *seq::Simulator::builder()
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
+        let mut s = seq::Simulator::builder()
                          .set_population(&population)
                          .set_selector(Box::new(selector))
                          .build();
@@ -277,8 +277,8 @@ mod tests {
     #[test]
     fn test_max_iters() {
         let selector = MaximizeSelector::new(2);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
-        let mut s = *seq::Simulator::builder()
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
+        let mut s = seq::Simulator::builder()
                          .set_population(&population)
                          .set_selector(Box::new(selector))
                          .set_max_iters(2)
@@ -290,8 +290,8 @@ mod tests {
     #[test]
     fn test_early_stopping() {
         let selector = MaximizeSelector::new(2);
-        let population: Vec<Box<Test>> = (0..100).map(|_| Box::new(Test { f: 0 })).collect();
-        let mut s = *seq::Simulator::builder()
+        let population: Vec<Test> = (0..100).map(|_| Test { f: 0 }).collect();
+        let mut s = seq::Simulator::builder()
                          .set_population(&population)
                          .set_early_stop(10.0, 5)
                          .set_max_iters(10)
@@ -303,8 +303,8 @@ mod tests {
     #[test]
     fn test_selector_error_propagate() {
         let selector = MaximizeSelector::new(0);
-        let population: Vec<Box<Test>> = (0..100).map(|i| Box::new(Test { f: i })).collect();
-        let mut s = *seq::Simulator::builder()
+        let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
+        let mut s = seq::Simulator::builder()
                          .set_population(&population)
                          .set_selector(Box::new(selector))
                          .build();


### PR DESCRIPTION
There's no need to allocate so much. You only really need to box things when you want runtime polymorphism (trait objects). However, you're using compiletime polymorphism (generics) for everything but selectors.
