### PR TITLE
Use pattern in closure arguments

### DIFF
--- a/examples/truck_loading.rs
+++ b/examples/truck_loading.rs
@@ -94,8 +94,8 @@ impl Phenotype for LoadingScheme {
         LoadingScheme {
             scheme: self.scheme
                         .iter()
-                        .map(|pair: &(TruckIndex, PackageSize)| {
-                            (rng.gen::<usize>() % NUM_TRUCKS, pair.1)
+                        .map(|&(_, size)| {
+                            (rng.gen::<usize>() % NUM_TRUCKS, size)
                         })
                         .collect(),
         }

--- a/src/sim/seq.rs
+++ b/src/sim/seq.rs
@@ -83,9 +83,7 @@ impl<T: Phenotype> Simulation<T> for Simulator<T> {
             };
             // Create children from the selected parents and mutate them.
             let mut children: Vec<T> = parents.iter()
-                                                   .map(|pair: &(T, T)| {
-                                                       pair.0.crossover(&(pair.1))
-                                                   })
+                                                   .map(|&(ref a, ref b)| a.crossover(b))
                                                    .map(|c| c.mutate())
                                                    .collect();
             // Kill off parts of the population at random to make room for the children


### PR DESCRIPTION
FYI, you can use irrefutable patterns in closure/function arguments to
destructure them. This is purely a matter of taste but I prefer to
destructure tuples rather than index into them.
