### PR TITLE
Fixed apparent bug with sorting for best fitness

### DIFF
--- a/src/sim/select/max.rs
+++ b/src/sim/select/max.rs
@@ -47,7 +47,7 @@ impl<T, F> Selector<T, F> for MaximizeSelector
         }
 
         let mut cloned = population.to_vec();
-        cloned.sort_by(|x, y| x.fitness().cmp(&y.fitness()));
+        cloned.sort_by(|x, y| y.fitness().cmp(&x.fitness()));
         let sorted: Vec<&T> = cloned.iter().take(self.count).collect();
         let mut index = 0;
         let mut result: Parents<T> = Vec::new();

--- a/src/sim/select/max.rs
+++ b/src/sim/select/max.rs
@@ -97,7 +97,7 @@ mod tests {
     fn test_result_ok() {
         let selector = MaximizeSelector::new(20);
         let population: Vec<Test> = (0..100).map(|i| Test { f: i }).collect();
-        // The lowest fitness should be zero.
-        assert!(selector.select(&population).unwrap()[0].0.fitness().f == 0);
+        // The greatest fitness should be 99.
+        assert!(selector.select(&population).unwrap()[0].0.fitness().f == 99);
     }
 }


### PR DESCRIPTION
Firstly, thanks for writing this!  I love the way you've laid out the `Phenotype` trait.

I had difficulty getting my GA to work correctly; the issue appears to be a bug in the `MaximizeSelector` structure implementation, which sorts elements based on ascending fitness [0].  This should be sorting based on descending fitness ([1] indicates that a better fitness should be > than a lesser fitness).

An alternative resolution for this issue is to just add `cloned.reverse()` but this should be more performant, though less obvious.

[0] - https://doc.rust-lang.org/std/vec/struct.Vec.html#method.sort_by
[1] - http://m-decoster.github.io/RsGenetic/doc/rsgenetic/pheno/trait.Fitness.html
