### PR TITLE
Avoid shifting population Vec in Simulator::kill_off()

### DIFF
--- a/src/sim/seq.rs
+++ b/src/sim/seq.rs
@@ -179,13 +179,10 @@ impl<'a, T, F> Simulator<'a, T, F>
     fn kill_off(&mut self, count: usize) {
         let ratio = self.population.len() / count;
         let mut i = ::rand::thread_rng().gen_range::<usize>(0, self.population.len());
-        let mut selected = 0;
-        while selected < count {
-            self.population.remove(i);
-            i += ratio - 1;
+        for _ in 0..count {
+            self.population.swap_remove(i);
+            i += ratio;
             i %= self.population.len();
-
-            selected += 1;
         }
     }
 }


### PR DESCRIPTION
Improves performance, especially for large populations and large selection sizes.

Drawback is that it may remove other individuals than the original implementation did. This is because an element that would have been removed in the original implementation may have been swapped with another element that was removed before it. I don't see this as a problem, but thought it was worth mentioning.