### PR TITLE
seq WASM compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/rsgenetic/"
 
 [dependencies]
-rand = "^0.5"
-rayon = "1.0.0"
+rand = "^0.5.4"
+rayon = "1.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ license = "MIT/Apache-2.0"
 documentation = "https://docs.rs/rsgenetic/"
 
 [dependencies]
-rand = "0.3"
+rand = "^0.5"
 rayon = "1.0.0"

--- a/examples/enum_phenotype.rs
+++ b/examples/enum_phenotype.rs
@@ -24,6 +24,7 @@ use rsgenetic::sim::*;
 use rsgenetic::sim::seq::Simulator;
 use rsgenetic::sim::select::*;
 use rsgenetic::pheno::*;
+use rsgenetic::stats::NoStats;
 
 #[derive(Clone, Copy, Debug)]
 struct MyPhenotype {
@@ -76,7 +77,7 @@ fn main() {
         population.push(MyPhenotype { variant: MyVariant::Variant2, value: i })
     }
     #[allow(deprecated)]
-    let mut s = Simulator::builder(&mut population)
+    let mut s: Simulator<_, _, NoStats> = Simulator::builder(&mut population)
         .set_selector(Box::new(MaximizeSelector::new(10)))
         .set_max_iters(100)
         .build();

--- a/examples/max_parabole.rs
+++ b/examples/max_parabole.rs
@@ -25,6 +25,7 @@ use rsgenetic::sim::select::*;
 use rsgenetic::pheno::*;
 use rand::distributions::{IndependentSample, Range};
 use std::cmp::Ordering;
+use rsgenetic::stats::NoStats;
 
 struct MyFitness {
     f: f64,
@@ -104,7 +105,7 @@ impl Clone for MyData {
 
 fn main() {
     let mut population = (-300..300).map(|i| MyData { x: f64::from(i) }).collect();
-    let mut s = Simulator::builder(&mut population)
+    let mut s: Simulator<_,_, NoStats> = Simulator::builder(&mut population)
         .set_selector(Box::new(StochasticSelector::new(10)))
         .set_max_iters(50)
         .build();

--- a/examples/max_parabole.rs
+++ b/examples/max_parabole.rs
@@ -25,7 +25,8 @@ use rsgenetic::sim::select::*;
 use rsgenetic::pheno::*;
 use rand::distributions::{IndependentSample, Range};
 use std::cmp::Ordering;
-use rsgenetic::stats::NoStats;
+use rsgenetic::stats::{StatsCollector, NoStats};
+
 
 struct MyFitness {
     f: f64,
@@ -62,6 +63,8 @@ impl Fitness for MyFitness {
         }
     }
 }
+impl StatsCollector<MyFitness> for NoStats {}
+
 
 struct MyData {
     x: f64,

--- a/examples/max_parabole_steps.rs
+++ b/examples/max_parabole_steps.rs
@@ -24,6 +24,7 @@ extern crate rsgenetic;
 use rsgenetic::sim::*;
 use rsgenetic::sim::seq::Simulator;
 use rsgenetic::sim::select::*;
+use rsgenetic::stats::NoStats;
 use rsgenetic::pheno::*;
 use rand::distributions::{IndependentSample, Range};
 use std::cmp::Ordering;
@@ -106,7 +107,7 @@ impl Clone for MyData {
 
 fn main() {
     let mut population = (-300..300).map(|i| MyData { x: f64::from(i) }).collect();
-    let mut s = Simulator::builder(&mut population)
+    let mut s: Simulator<_, _, NoStats> = Simulator::builder(&mut population)
         .set_selector(Box::new(StochasticSelector::new(10)))
         .set_max_iters(50)
         .build();

--- a/examples/max_parabole_steps.rs
+++ b/examples/max_parabole_steps.rs
@@ -24,7 +24,7 @@ extern crate rsgenetic;
 use rsgenetic::sim::*;
 use rsgenetic::sim::seq::Simulator;
 use rsgenetic::sim::select::*;
-use rsgenetic::stats::NoStats;
+use rsgenetic::stats::{NoStats, StatsCollector};
 use rsgenetic::pheno::*;
 use rand::distributions::{IndependentSample, Range};
 use std::cmp::Ordering;
@@ -64,6 +64,8 @@ impl Fitness for MyFitness {
         }
     }
 }
+impl StatsCollector<MyFitness> for NoStats {}
+
 
 struct MyData {
     x: f64,

--- a/examples/truck_loading.rs
+++ b/examples/truck_loading.rs
@@ -25,6 +25,7 @@ extern crate rand;
 extern crate rsgenetic;
 
 use rsgenetic::sim::*;
+use rsgenetic::stats::NoStats;
 use rsgenetic::sim::seq::Simulator;
 use rsgenetic::sim::select::*;
 use rsgenetic::pheno::*;
@@ -126,7 +127,7 @@ fn main() {
         population.push(LoadingScheme { scheme: pheno });
     }
     #[allow(deprecated)]
-    let mut s = Simulator::builder(&mut population)
+    let mut s: Simulator<_, _, NoStats> = Simulator::builder(&mut population)
         .set_selector(Box::new(MaximizeSelector::new(10)))
         .set_max_iters(100)
         .build();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,10 @@ extern crate rayon;
 
 /// Contains the definition of a Phenotype.
 pub mod pheno;
+
+/// Contains a way to collect information on steps via a trait.
+pub mod stats;
+
 /// Contains implementations of Simulators, which can run genetic algorithms.
 pub mod sim;
 /// Contains code used by unit tests.

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -65,7 +65,7 @@ pub trait Simulation<'a, T, F, S>
 where
     T: Phenotype<F>,
     F: Fitness,
-    S: StatsCollector,
+    S: StatsCollector<F>,
 {
     /// A `Builder` is used to create instances of a `Simulation`.
     type B: Builder<Self>;

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -15,6 +15,9 @@
 // limitations under the License.
 
 use pheno::{Fitness, Phenotype};
+use stats::StatsCollector;
+use std::cell::RefCell;
+use std::rc::Rc;
 
 pub mod seq;
 pub mod select;
@@ -58,13 +61,23 @@ pub enum RunResult {
 }
 
 /// A `Simulation` is an execution of a genetic algorithm.
-pub trait Simulation<'a, T, F>
+pub trait Simulation<'a, T, F, S>
 where
     T: Phenotype<F>,
     F: Fitness,
+    S: StatsCollector,
 {
     /// A `Builder` is used to create instances of a `Simulation`.
     type B: Builder<Self>;
+
+
+    /// Create a `Builder` to create an instance.
+    ///
+    /// `population` is a required parameter of any `Simulation`, which
+    /// is why it is a parameter of this function.
+    fn builder_with_stats(population: &'a mut Vec<T>, sc: Option<Rc<RefCell<S>>>) -> Self::B
+    where
+        Self: Sized;
 
     /// Create a `Builder` to create an instance.
     ///

--- a/src/sim/seq.rs
+++ b/src/sim/seq.rs
@@ -53,7 +53,7 @@ pub struct Simulator<'a, T, F, S>
 where
     T: 'a + Phenotype<F>,
     F: Fitness,
-    S: StatsCollector,
+    S: StatsCollector<F>,
 {
     population: &'a mut Vec<T>,
     iter_limit: IterLimit,
@@ -71,7 +71,7 @@ impl<'a, T, F, S> Simulation<'a, T, F, S> for Simulator<'a, T, F, S>
 where
     T: Phenotype<F>,
     F: Fitness,
-    S: StatsCollector,
+    S: StatsCollector<F>,
 {
     type B = SimulatorBuilder<'a, T, F, S>;
     
@@ -132,7 +132,8 @@ where
         };
 
         if let Some(ref mut s) = self.stats {
-            s.borrow_mut().before_step(&self.population.into_iter().map(|p| p.fitness()));
+            let fitness: Vec<F> = self.population.into_iter().map(|p| p.fitness()).collect();
+            s.borrow_mut().before_step(&fitness);
         }
 
         if !should_stop {
@@ -169,7 +170,8 @@ where
             self.iter_limit.inc();
 
             if let Some(ref mut s) = self.stats {
-                s.borrow_mut().after_step(&self.population.into_iter().map(|p| p.fitness()));
+                let fitness: Vec<F> = self.population.into_iter().map(|p| p.fitness()).collect();
+                s.borrow_mut().after_step(&fitness);
             }
 
             StepResult::Success // Not done yet, but successful
@@ -223,7 +225,7 @@ impl<'a, T, F, S> Simulator<'a, T, F, S>
 where
     T: Phenotype<F>,
     F: Fitness,
-    S: StatsCollector,
+    S: StatsCollector<F>,
 {
     /// Kill off phenotypes using stochastic universal sampling.
     fn kill_off(&mut self, count: usize) {
@@ -243,7 +245,7 @@ pub struct SimulatorBuilder<'a, T, F, S>
 where
     T: 'a + Phenotype<F>,
     F: Fitness,
-    S: StatsCollector,
+    S: StatsCollector<F>,
 {
     sim: Simulator<'a, T, F, S>,
 }
@@ -252,7 +254,7 @@ impl<'a, T, F, S> SimulatorBuilder<'a, T, F, S>
 where
     T: Phenotype<F>,
     F: Fitness,
-    S: StatsCollector,
+    S: StatsCollector<F>,
 {
     /// Set the selector of the resulting `Simulator`.
     ///
@@ -308,7 +310,7 @@ impl<'a, T, F, S> Builder<Simulator<'a, T, F, S>> for SimulatorBuilder<'a, T, F,
 where
     T: Phenotype<F>,
     F: Fitness,
-    S: StatsCollector,
+    S: StatsCollector<F>,
 {
     fn build(self) -> Simulator<'a, T, F, S> {
         self.sim

--- a/src/sim/seq.rs
+++ b/src/sim/seq.rs
@@ -25,6 +25,7 @@ use pheno::Fitness;
 use stats::StatsCollector;
 
 use rand::prelude::*;
+use rand::rngs::*;
 use stats::NoStats;
 use rand::Rng;
 use rand::SeedableRng;
@@ -35,14 +36,14 @@ use super::iterlimit::*;
 use super::earlystopper::*;
 use std::boxed::Box;
 use std::marker::PhantomData;
-use rand::rngs::OsRng;
+
 use std::rc::Rc;
 use std::cell::RefCell;
 
-#[cfg(not(target="wasm32-unknown-unknown"))]
+#[cfg(not(target_arch="wasm32"))]
 type RandomGenerator = OsRng;
 
-#[cfg(target="wasm32-unknown-unknown")]
+#[cfg(target_arch="wasm32")]
 type RandomGenerator = XorShiftRng;
 
 
@@ -76,7 +77,7 @@ where
     type B = SimulatorBuilder<'a, T, F, S>;
     
     #[allow(deprecated)]
-    #[cfg(not(target="wasm32-unknown-unknown"))]
+    #[cfg(not(target_arch="wasm32"))]
     fn builder_with_stats(population: &'a mut Vec<T>, sc: Option<Rc<RefCell<S>>>) -> SimulatorBuilder<'a, T, F, S> {
         SimulatorBuilder {
             sim: Simulator {
@@ -92,9 +93,9 @@ where
         }
     }
 
-    #[cfg(target="wasm32-unknown-unknown")]
+    #[cfg(target_arch="wasm32")]
     fn builder_with_stats(population: &'a mut Vec<T>, sc: Option<Rc<RefCell<S>>>) -> SimulatorBuilder<'a, T, F, S> {
-        let seed = [0u32, 0u32, 0u32, 1u32];
+        let seed = [0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 1u8];
         SimulatorBuilder {
             sim: Simulator {
                 population: population,
@@ -104,7 +105,7 @@ where
                 error: None,
                 phantom: PhantomData::default(),
                 stats: sc,
-                rng: Rc::new(RefCell::new(XorShiftRng::from_seed(seed).unwrap())),
+                rng: Rc::new(RefCell::new(XorShiftRng::from_seed(seed))),
             },
         }
     }
@@ -324,7 +325,6 @@ mod tests {
     use sim::select::*;
     use test::Test;
     use test::MyFitness;
-    use rand::OsRng;
     use stats::NoStats;
 
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -18,21 +18,22 @@ use pheno::Fitness;
 
 /// A collector for potential stats on the population's fitness or timing.
 ///
-pub trait StatsCollector
+pub trait StatsCollector<F: Fitness>
 {
     ///Executed before a step, passing the current population's fitness
     ///
-    fn before_step<F>(&mut self, pop_fitness: &Iterator<Item = F>) where
-    F: Fitness {}
+    fn before_step(&mut self, pop_fitness: &[F]) {}
 
     /// Executed after a step passing in the current population's fitness.
     ///
-    fn after_step<F>(&mut self, pop_fitness: &Iterator<Item = F>) where
-    F: Fitness {}
+    fn after_step(&mut self, pop_fitness: &[F]) {}
 }
 
 /// A NOOP implementation for common fitness types
 /// 
 #[derive(Debug, Clone, Copy)]
 pub struct NoStats {}
-impl StatsCollector for NoStats {}
+impl StatsCollector<i32> for NoStats {}
+impl StatsCollector<i64> for NoStats {}
+impl StatsCollector<u32> for NoStats {}
+impl StatsCollector<u64> for NoStats {}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,38 @@
+// file: stats.rs
+//
+// Copyright 2015-2017 The RsGenetic Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pheno::Fitness;
+
+/// A collector for potential stats on the population's fitness or timing.
+///
+pub trait StatsCollector
+{
+    ///Executed before a step, passing the current population's fitness
+    ///
+    fn before_step<F>(&mut self, pop_fitness: &Iterator<Item = F>) where
+    F: Fitness {}
+
+    /// Executed after a step passing in the current population's fitness.
+    ///
+    fn after_step<F>(&mut self, pop_fitness: &Iterator<Item = F>) where
+    F: Fitness {}
+}
+
+/// A NOOP implementation for common fitness types
+/// 
+#[derive(Debug, Clone, Copy)]
+pub struct NoStats {}
+impl StatsCollector for NoStats {}

--- a/src/test.rs
+++ b/src/test.rs
@@ -19,6 +19,8 @@
 
 use pheno::*;
 use std::cmp;
+use stats::{StatsCollector, NoStats};
+
 
 #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
 pub struct MyFitness {
@@ -36,6 +38,8 @@ impl Fitness for MyFitness {
         }
     }
 }
+
+
 
 #[derive(Clone, Copy)]
 pub struct Test {
@@ -63,3 +67,5 @@ impl Phenotype<MyFitness> for Test {
         }
     }
 }
+
+impl StatsCollector<MyFitness> for NoStats {}


### PR DESCRIPTION
Hi! So these are the (minor) changes to the seq module (incl. the update to the WASM compatible 0.5 `rand` crate). 

I think there are a few things that are worth doing:
- the iteration timing is useful for wherever `Instant` is available, WASM bindgen doesn't support it yet though.
- the random `thread_rng` number generator [doesn't work with WASM bindgen yet](https://github.com/rustwasm/wasm-bindgen/issues/224), a good solution would probably be to be able to pass in a custom RNG (like `Math.random` or `XorShiftRng`). 

This PR should mostly show the required changes to `seq`. I am happy to use a completely different approach too!

Tracked also in #32 